### PR TITLE
Changement d'id pour deux craft.

### DIFF
--- a/recette_pack/data/recettes_vanilla/recipes/bone.json
+++ b/recette_pack/data/recettes_vanilla/recipes/bone.json
@@ -6,7 +6,7 @@
                },
          
                {
-                   "item": "minecraft:dye"
+                   "item": "minecraft:light_gray_dye"
                }
 
        ],

--- a/recette_pack/data/recettes_vanilla/recipes/horse_armor_diamond.json
+++ b/recette_pack/data/recettes_vanilla/recipes/horse_armor_diamond.json
@@ -6,7 +6,7 @@
     "121"
   ],
   "key": {
-    "#": {
+    "1": {
       "item": "minecraft:diamond"
     },
     "2": {


### PR DESCRIPTION
Changement nécessaire car nouveau nom d’id pour les dernières versions.